### PR TITLE
Refactoring - notice 

### DIFF
--- a/src/decorators/docs/notice.decorator.ts
+++ b/src/decorators/docs/notice.decorator.ts
@@ -13,15 +13,11 @@ import { DocumentedException } from 'src/interfaces/docsException';
 import { NoticeInfoResponseDto } from 'src/notice/dtos/NoticeInfoResponse.dto';
 import { PagedNoticeListDto } from 'src/notice/dtos/NoticeListResponse.dto';
 
-type NoticeEndpoints =
-  | 'getNoticeListByFiltersOrderByDate'
-  | 'getNoticeInfoById'
-  | 'searchNotice'
-  | 'scrapNotice';
+type NoticeEndpoints = 'getNoticeList' | 'getNoticeInfoById' | 'scrapNotice';
 
 export function Docs(endPoint: NoticeEndpoints) {
   switch (endPoint) {
-    case 'getNoticeListByFiltersOrderByDate':
+    case 'getNoticeList':
       return applyDecorators(
         ApiOperation({
           summary: '공지 리스트 조회 by filter',
@@ -45,6 +41,13 @@ export function Docs(endPoint: NoticeEndpoints) {
           required: false,
           example: 1,
           description: '1 for default',
+        }),
+        ApiQuery({
+          name: 'keyword',
+          type: String,
+          required: false,
+          example: '장학',
+          description: '검색어를 입력',
         }),
         ApiQuery({
           name: 'providers',
@@ -101,39 +104,6 @@ export function Docs(endPoint: NoticeEndpoints) {
           description: 'notice id',
           example: 1,
           required: true,
-        }),
-      );
-    case 'searchNotice':
-      return applyDecorators(
-        ApiOperation({
-          summary: '공지사항 검색',
-          description:
-            '공지사항을 검색합니다. search keyword로 제목, 내용, 글쓴이를 기준으로 검색합니다. Authorization 헤더에 Bearer ${accessToken} 을 넣어주세요.',
-        }),
-        ApiOkResponse({
-          description: 'well done',
-          type: PagedNoticeListDto,
-        }),
-        ApiInternalServerErrorResponse({
-          description: 'internal server error',
-        }),
-        ApiUnauthorizedResponse({
-          description: 'token 만료 또는 잘못된 token',
-          type: DocumentedException,
-        }),
-        ApiQuery({
-          name: 'page',
-          type: Number,
-          required: false,
-          example: 1,
-          description: '1 for default',
-        }),
-        ApiQuery({
-          name: 'keyword',
-          type: String,
-          required: true,
-          example: '장학금',
-          description: '검색 키워드',
         }),
       );
     case 'scrapNotice':

--- a/src/entities/scrap.entity.ts
+++ b/src/entities/scrap.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  RelationId,
+} from 'typeorm';
 import { Notice } from 'src/entities';
 import { ScrapBox } from './scrapBox.entity';
 
@@ -18,4 +25,8 @@ export class Scrap {
   })
   @JoinColumn({ name: 'notice_id' })
   notice: Notice;
+
+  @RelationId((scrap: Scrap) => scrap.notice)
+  @Column({ name: 'notice_id' })
+  noticeId: number;
 }

--- a/src/notice/dtos/NoticeInfoResponse.dto.ts
+++ b/src/notice/dtos/NoticeInfoResponse.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { Notice, ScrapBox } from 'src/entities';
 
 export class NoticeInfoResponseDto {
   @ApiProperty({ description: '공지사항 ID', example: 1 })
@@ -111,4 +112,44 @@ export class NoticeInfoResponseDto {
     examples: ['학부 공지사항, 장학 정보'],
   })
   category: string;
+
+  @ApiProperty({
+    description: '공지 사항이 포함된 스크랩박스들의 id',
+    example: [1, 2, 3],
+  })
+  scrapBoxId: number[];
+
+  @ApiProperty({
+    description: '전처리된 카테고리',
+    example: '장학정보',
+  })
+  mappedCategory: string;
+
+  static entityToDto(
+    entity: Notice,
+    scrapBoxes?: ScrapBox[],
+  ): NoticeInfoResponseDto {
+    const scrapBoxIds = scrapBoxes
+      ? scrapBoxes
+          .filter((scrapBox) =>
+            scrapBox.scraps.some((scrap) => scrap.noticeId === entity.id),
+          )
+          .map((scrapBox) => scrapBox.id)
+      : [];
+    return {
+      id: entity.id,
+      title: entity.title,
+      content: entity.content,
+      writer: entity.writer,
+      date: entity.date,
+      view: entity.view,
+      url: entity.url,
+      scrapped: scrapBoxIds.length > 0,
+      scrapCount: entity.scraps.length,
+      provider: entity.category.provider.name,
+      category: entity.category.name,
+      mappedCategory: entity.category.mappedCategory,
+      scrapBoxId: scrapBoxIds,
+    };
+  }
 }

--- a/src/notice/dtos/NoticeListResponse.dto.ts
+++ b/src/notice/dtos/NoticeListResponse.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Notice } from 'src/entities';
+import { Notice, ScrapBox } from 'src/entities';
 
 export class NoticeListResponseDto {
   @ApiProperty({ description: '공지사항 ID', example: 1 })
@@ -17,12 +17,40 @@ export class NoticeListResponseDto {
   @ApiProperty({ description: '공지사항 작성일', example: '2023-11-07' })
   date: string;
 
-  static entityToDto(entity: Notice, scrapped: boolean = false) {
+  @ApiProperty({
+    description: '전처리된 카테고리 정보',
+    example: '학사일정',
+  })
+  mappedCategory: string;
+
+  @ApiProperty({ description: '학과 정보', example: '컴퓨터학과' })
+  provider: string;
+
+  @ApiProperty({
+    description: '공지 사항이 포함된 스크랩박스들의 id',
+    example: [1, 2, 3],
+  })
+  scrapBoxId: number[];
+
+  static entityToDto(
+    entity: Notice,
+    scrapBoxes: ScrapBox[],
+  ): NoticeListResponseDto {
+    const scrapBoxIds = scrapBoxes
+      ? scrapBoxes
+          .filter((scrapBox) =>
+            scrapBox.scraps.some((scrap) => scrap.noticeId === entity.id),
+          )
+          .map((scrapBox) => scrapBox.id)
+      : [];
     return {
       id: entity.id,
       title: entity.title,
-      scrapped,
+      scrapped: scrapBoxIds.length > 0,
       date: entity.date,
+      provider: entity.category.provider.name,
+      mappedCategory: entity.category.mappedCategory,
+      scrapBoxId: scrapBoxIds,
     };
   }
 }

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -7,6 +7,7 @@ import { NoticeFilterRequestDto } from './dtos/NoticeFilterRequest.dto';
 import { Docs } from 'src/decorators/docs/notice.decorator';
 import { User } from 'src/decorators';
 import { JwtPayload } from 'src/interfaces/auth';
+import { NoticeInfoResponseDto } from './dtos/NoticeInfoResponse.dto';
 
 @Controller('notice')
 @ApiTags('notice')
@@ -14,17 +15,19 @@ export class NoticeController {
   constructor(private readonly noticeService: NoticeService) {}
 
   @UseGuards(AuthGuard('jwt-access'))
-  @Get('/list/filter')
-  @Docs('getNoticeListByFiltersOrderByDate')
-  async getNoticeListByFiltersOrderByDate(
+  @Get('/list')
+  @Docs('getNoticeList')
+  async getNoticeList(
     @Query() filter: NoticeFilterRequestDto,
     @Query('page') page: number,
     @User() user: JwtPayload,
+    @Query('keyword') keyword?: string,
   ): Promise<PagedNoticeListDto> {
-    return await this.noticeService.getNoticesByFilterOrderByDate(
+    return await this.noticeService.getNoticeList(
       user.id,
       filter,
       page,
+      keyword,
     );
   }
 
@@ -42,18 +45,10 @@ export class NoticeController {
   @UseGuards(AuthGuard('jwt-access'))
   @Get('/info/:id')
   @Docs('getNoticeInfoById')
-  async getNoticeInfoById(@Param('id') id: number) {
-    return await this.noticeService.getNoticeInfoById(id);
-  }
-
-  @UseGuards(AuthGuard('jwt-access'))
-  @Get('/list/search')
-  @Docs('searchNotice')
-  async searchNotice(
-    @Query('keyword') keyword: string,
-    @Query('page') page: number,
+  async getNoticeInfoById(
+    @Param('id') id: number,
     @User() user: JwtPayload,
-  ) {
-    return await this.noticeService.searchNotice(keyword, user.id, page);
+  ): Promise<NoticeInfoResponseDto> {
+    return await this.noticeService.getNoticeInfoById(id, user.id);
   }
 }

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Notice, Scrap, ScrapBox } from 'src/entities';
-import { Between, In, Repository } from 'typeorm';
+import { Repository } from 'typeorm';
 import {
   NoticeListResponseDto,
   PagedNoticeListDto,
@@ -24,10 +24,11 @@ export class NoticeService {
     private readonly scrapBoxRepository: Repository<ScrapBox>,
   ) {}
 
-  async getNoticesByFilterOrderByDate(
+  async getNoticeList(
     userId: number,
     filter: NoticeFilterRequestDto,
     page: number = 1,
+    keyword?: string,
   ): Promise<PagedNoticeListDto> {
     const {
       categories,
@@ -35,104 +36,54 @@ export class NoticeService {
       start_date = '2020-01-01',
       end_date = '2040-01-01',
     } = filter;
+
     const categoryList = categories?.split(',') || [];
     const providerList = providers?.split(',') || [];
 
-    const scraps = await this.scrapRepository.find({
+    const scrapBoxes = await this.scrapBoxRepository.find({
       where: {
-        scrapBox: {
-          user: { id: userId },
-        },
+        user: { id: userId },
       },
-      relations: ['notice'],
+      relations: ['scraps'],
     });
-
-    const [notices, total] = await this.noticeRepository.findAndCount({
-      where: {
-        date: Between(start_date, end_date),
-        category: {
-          mappedCategory: categoryList.length > 0 ? In(categoryList) : null,
-          provider: {
-            name: providerList.length > 0 ? In(providerList) : null,
-          },
-        },
-      },
-      skip: (page - 1) * 10,
-      take: 10,
-      order: {
-        date: 'DESC',
-      },
-    });
-
-    const dtos: NoticeListResponseDto[] = notices.map((notice) => {
-      const { id, title, date } = notice;
-      return {
-        id,
-        title,
-        date,
-        scrapped: scraps.some((scrap) => scrap.notice.id === id),
-      };
-    });
-    return {
-      notices: dtos,
-      page: page,
-      totalNotice: total,
-      totalPage: Math.ceil(total / 10),
-    };
-  }
-
-  async getNoticeInfoById(id: number) {
-    const notice = await this.noticeRepository.findOne({
-      where: { id },
-      relations: ['category', 'category.provider'],
-    });
-    notice.view += 1;
-    await this.noticeRepository.save(notice);
-
-    const dto: NoticeInfoResponseDto = {
-      id: notice.id,
-      title: notice.title,
-      content: notice.content,
-      date: notice.date,
-      view: notice.view,
-      url: notice.url,
-      scrapped: false,
-      writer: notice.writer,
-      scrapCount: 0,
-      category: notice.category.name,
-      provider: notice.category.provider.name,
-    };
-    return dto;
-  }
-
-  async searchNotice(keyword: string, userId: number, page: number = 1) {
-    const scraps = await this.scrapRepository.find({
-      where: {
-        scrapBox: {
-          user: { id: userId },
-        },
-      },
-      relations: ['notice'],
-    });
-
-    const [notices, total] = await this.noticeRepository
+    const queryBuilder = this.noticeRepository
       .createQueryBuilder('notice')
-      .where('notice.title like :keyword', { keyword: `%${keyword}%` })
-      .orWhere('notice.content like :keyword', { keyword: `%${keyword}%` })
-      .orWhere('notice.writer like :keyword', { keyword: `%${keyword}%` })
+      .leftJoinAndSelect('notice.category', 'category')
+      .leftJoinAndSelect('category.provider', 'provider')
+      .leftJoinAndSelect('notice.scraps', 'scraps')
+      .where('notice.date BETWEEN :start_date AND :end_date', {
+        start_date,
+        end_date,
+      });
+
+    if (categoryList.length > 0) {
+      queryBuilder.andWhere('category.mappedCategory IN (:...categoryList)', {
+        categoryList,
+      });
+    }
+
+    if (providerList.length > 0) {
+      queryBuilder.andWhere('provider.name IN (:...providerList)', {
+        providerList,
+      });
+    }
+    if (keyword) {
+      queryBuilder.andWhere(
+        '(notice.title like :keyword OR notice.content like :keyword OR notice.writer like :keyword)',
+        {
+          keyword: `%${keyword}%`,
+        },
+      );
+    }
+
+    const [notices, total] = await queryBuilder
       .orderBy('notice.date', 'DESC')
       .skip((page - 1) * 10)
       .take(10)
       .getManyAndCount();
 
     const dtos: NoticeListResponseDto[] = notices.map((notice) => {
-      const { id, title, date } = notice;
-      return {
-        id,
-        title,
-        date,
-        scrapped: scraps.some((scrap) => scrap.notice.id === id),
-      };
+      return NoticeListResponseDto.entityToDto(notice, scrapBoxes);
     });
     return {
       notices: dtos,
@@ -140,6 +91,24 @@ export class NoticeService {
       totalNotice: total,
       totalPage: Math.ceil(total / 10),
     };
+  }
+
+  async getNoticeInfoById(
+    id: number,
+    userId: number,
+  ): Promise<NoticeInfoResponseDto> {
+    const notice = await this.noticeRepository.findOne({
+      where: { id },
+      relations: ['category', 'category.provider', 'scraps'],
+    });
+    notice.view += 1;
+    await this.noticeRepository.save(notice);
+    const scrapBoxes = await this.scrapBoxRepository.find({
+      where: { user: { id: userId } },
+      relations: ['scraps'],
+    });
+
+    return NoticeInfoResponseDto.entityToDto(notice, scrapBoxes);
   }
 
   async scrapNotice(

--- a/src/scrap/dtos/scrapBoxResponse.dto.ts
+++ b/src/scrap/dtos/scrapBoxResponse.dto.ts
@@ -15,7 +15,7 @@ export class ScrapBoxResponseDto extends ScrapBoxRequestDto {
   })
   noticeCount: number;
 
-  static entityToDto(entity: ScrapBox) {
+  static entityToDto(entity: ScrapBox): ScrapBoxResponseDto {
     return {
       noticeCount: entity.scraps ? entity.scraps.length : 0,
       id: entity.id,

--- a/src/scrap/dtos/scrapBoxResponseWithNotices.dto.ts
+++ b/src/scrap/dtos/scrapBoxResponseWithNotices.dto.ts
@@ -9,7 +9,7 @@ export class ScrapBoxResponseWithNotices extends ScrapBoxResponseDto {
   })
   notices: NoticeListResponseDto[];
 
-  static entityToDto(entity: ScrapBox) {
+  static entityToDto(entity: ScrapBox): ScrapBoxResponseWithNotices {
     return {
       ...super.entityToDto(entity),
       notices: entity.scraps.map((scrap) =>

--- a/src/scrap/dtos/scrapBoxResponseWithNotices.dto.ts
+++ b/src/scrap/dtos/scrapBoxResponseWithNotices.dto.ts
@@ -9,11 +9,14 @@ export class ScrapBoxResponseWithNotices extends ScrapBoxResponseDto {
   })
   notices: NoticeListResponseDto[];
 
-  static entityToDto(entity: ScrapBox): ScrapBoxResponseWithNotices {
+  static toDto(
+    entity: ScrapBox,
+    others: ScrapBox[],
+  ): ScrapBoxResponseWithNotices {
     return {
       ...super.entityToDto(entity),
       notices: entity.scraps.map((scrap) =>
-        NoticeListResponseDto.entityToDto(scrap.notice, true),
+        NoticeListResponseDto.entityToDto(scrap.notice, others),
       ),
     };
   }

--- a/src/scrap/scrap.service.ts
+++ b/src/scrap/scrap.service.ts
@@ -42,11 +42,15 @@ export class ScrapService {
       where: { id: scrapBoxId },
       relations: ['scraps', 'scraps.notice'],
     });
+    const scrapBoxes = await this.scrapBoxRepository.find({
+      where: { user: { id: userId } },
+      relations: ['scraps'],
+    });
     if (!scrapBox)
       throw new NotFoundException('해당 ScrapBox가 존재하지 않습니다');
     if (scrapBox.userId !== userId)
       throw new ForbiddenException('권한이 없습니다');
-    return ScrapBoxResponseWithNotices.entityToDto(scrapBox);
+    return ScrapBoxResponseWithNotices.toDto(scrapBox, scrapBoxes);
   }
 
   async getScrapBoxes(userId: number): Promise<ScrapBoxResponseDto[]> {


### PR DESCRIPTION
- 공지사항 List api
    - scrap 정보를 줄 때, 기존에는 Scrap 엔티티를 참고하였으나, scrapBox entity를 모두 가져와 유저 소유의 스크랩 박스 중 하나에라도 스크랩 되어있으면 true를 반환하도록 했습니다
    - 저번 주 회의 결과, 리스트에서 스크랩 박스 중 어떤 것에 들어있는지 정보가 필요하여 notice 가 스크랩 된 스크랩박스 id를 리턴하도록 했습니다.
    - 학과, Mapped category 정보를 리턴하도록 바궜습니다.
    - 기존의 검색 api와 통합하여, 필터와 검색이 동시에 가능하도록 변경했습니다. 이를 위해 queryBuilder를 사용하도록 바꿨습니다.
- 공지사항 세부정보 api
    - scrap수를 다시 지원하도록 바꿨습니다.
    - 역시, 어떤 스크랩박스에 들어있는지 넣었습니다.

기능을 좀 추가하느라 코드도 더럽고 불필요한 쿼리가 많은데,, 완성하고 나서 수정해봐요