### PR TITLE
Feat: subscribe

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import { ProviderModule } from './provider/provider.module';
 import { ChannelModule } from './channel/channel.module';
 import { UsersModule } from './users/users.module';
 import { ScrapModule } from './scrap/scrap.module';
+import { SubscribeModule } from './subscribe/subscribe.module';
 
 @Module({
   imports: [
@@ -48,6 +49,7 @@ import { ScrapModule } from './scrap/scrap.module';
     ChannelModule,
     UsersModule,
     ScrapModule,
+    SubscribeModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/decorators/docs/subscribe.decorator.ts
+++ b/src/decorators/docs/subscribe.decorator.ts
@@ -1,0 +1,168 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiCreatedResponse,
+  ApiForbiddenResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+import { DocumentedException } from 'src/interfaces/docsException';
+import { SubscribeBoxRequestDto } from 'src/subscribe/dtos/subscribeBoxRequest.dto';
+import { SubscribeBoxResponseDto } from 'src/subscribe/dtos/subscribeBoxResponse.dto';
+import { SubscribeBoxResponseDtoWithNotices } from 'src/subscribe/dtos/subscribeBoxResponseWithNotices.dto';
+
+type SubscribeEndPoint =
+  | 'createSubscribeBox'
+  | 'getSubscribeBoxInfo'
+  | 'getSubscribeBoxes'
+  | 'updateSubscribeBox'
+  | 'deleteSubscribeBox';
+
+export function Docs(endPoint: SubscribeEndPoint) {
+  switch (endPoint) {
+    case 'createSubscribeBox':
+      return applyDecorators(
+        ApiOperation({
+          summary: '구독함 생성',
+          description:
+            '새 구독함를 생성합니다. Authorization 헤더에 Bearer ${accessToken} 을 넣어주세요.',
+        }),
+        ApiBody({
+          description: '구독함 정보',
+          type: SubscribeBoxRequestDto,
+        }),
+        ApiCreatedResponse({
+          description:
+            '구독함이 성공적으로 생성되었습니다. 만들어진 박스 정보를 반환합니다.',
+          type: SubscribeBoxResponseDto,
+        }),
+        ApiUnauthorizedResponse({
+          description: 'token 만료 또는 잘못된 token',
+          type: DocumentedException,
+        }),
+      );
+    case 'getSubscribeBoxInfo':
+      return applyDecorators(
+        ApiOperation({
+          summary: '구독함 날짜별 세부 정보 열람',
+          description:
+            '구독함 정보 + 구독함에 포함된 해당 날짜의 공지사항들을 반환합니다. Authorization 헤더에 Bearer ${accessToken} 을 넣어주세요.',
+        }),
+        ApiParam({
+          name: 'subscribeBoxId',
+          description: '열람할 구독함의 id',
+          type: Number,
+          required: true,
+          example: 1,
+        }),
+        ApiQuery({
+          name: 'date',
+          description: '열람할 날짜',
+          type: String,
+          required: true,
+          example: '2024-04-08',
+        }),
+        ApiOkResponse({
+          description: '구독함 정보 + 구독함에 포함된 공지사항들',
+          type: SubscribeBoxResponseDtoWithNotices,
+        }),
+        ApiUnauthorizedResponse({
+          description: 'token 만료 또는 잘못된 token',
+          type: DocumentedException,
+        }),
+        ApiForbiddenResponse({
+          description: 'userId와 구독함 소유자의 id가 다릅니다.',
+          type: DocumentedException,
+        }),
+        ApiNotFoundResponse({
+          description: '구독함 Id에 해당하는 구독함이 없습니다.',
+          type: DocumentedException,
+        }),
+      );
+    case 'getSubscribeBoxes':
+      return applyDecorators(
+        ApiOperation({
+          summary: '구독함 목록 조회',
+          description:
+            '사용자의 구독함 목록을 조회합니다. Authorization 헤더에 Bearer ${accessToken} 을 넣어주세요.',
+        }),
+        ApiOkResponse({
+          description: '사용자의 구독함 목록',
+          type: [SubscribeBoxResponseDto],
+        }),
+        ApiUnauthorizedResponse({
+          description: 'token 만료 또는 잘못된 token',
+          type: DocumentedException,
+        }),
+      );
+    case 'updateSubscribeBox':
+      return applyDecorators(
+        ApiOperation({
+          summary: '구독함 정보 수정',
+          description:
+            '구독함의 정보를 수정합니다. Authoization 헤더에 Bearer ${accessToken}을 넣어주세요',
+        }),
+        ApiParam({
+          name: 'scrapBoxId',
+          description: '수정할 구독함의 id',
+          type: Number,
+          required: true,
+          example: 1,
+        }),
+        ApiBody({
+          description: '구독함 정보들',
+          type: SubscribeBoxRequestDto,
+        }),
+        ApiOkResponse({
+          description: '구독함 수정 성공, 변경된 구독함의 정보가 반환됩니다.',
+          type: SubscribeBoxResponseDto,
+        }),
+        ApiUnauthorizedResponse({
+          description: 'token 만료 또는 잘못된 token',
+          type: DocumentedException,
+        }),
+        ApiForbiddenResponse({
+          description: 'userId와 구독함 소유자의 id가 다릅니다.',
+          type: DocumentedException,
+        }),
+        ApiNotFoundResponse({
+          description: '구독함 Id에 해당하는 구독함이 없습니다.',
+          type: DocumentedException,
+        }),
+      );
+    case 'deleteSubscribeBox':
+      return applyDecorators(
+        ApiOperation({
+          summary: '구독함 삭제',
+          description:
+            'id에 맞는 구독함을 삭제합니다. Authoization 헤더에 Bearer ${accessToken}을 넣어주세요',
+        }),
+        ApiParam({
+          name: 'subscribeBoxId',
+          description: '구독함의 id',
+          type: Number,
+          required: true,
+          example: 1,
+        }),
+        ApiOkResponse({
+          description: '스크랩박스 삭제 성공',
+        }),
+        ApiUnauthorizedResponse({
+          description: 'token 만료 또는 잘못된 token',
+          type: DocumentedException,
+        }),
+        ApiForbiddenResponse({
+          description: 'userId와 scrapBox 소유자의 id가 다릅니다.',
+          type: DocumentedException,
+        }),
+        ApiNotFoundResponse({
+          description: 'scrapBox Id에 해당하는 박스가 없습니다.',
+          type: DocumentedException,
+        }),
+      );
+  }
+}

--- a/src/decorators/docs/subscribe.decorator.ts
+++ b/src/decorators/docs/subscribe.decorator.ts
@@ -149,18 +149,18 @@ export function Docs(endPoint: SubscribeEndPoint) {
           example: 1,
         }),
         ApiOkResponse({
-          description: '스크랩박스 삭제 성공',
+          description: '구독함 삭제 성공',
         }),
         ApiUnauthorizedResponse({
           description: 'token 만료 또는 잘못된 token',
           type: DocumentedException,
         }),
         ApiForbiddenResponse({
-          description: 'userId와 scrapBox 소유자의 id가 다릅니다.',
+          description: 'userId와 구독함 소유자의 id가 다릅니다.',
           type: DocumentedException,
         }),
         ApiNotFoundResponse({
-          description: 'scrapBox Id에 해당하는 박스가 없습니다.',
+          description: '구독함 Id에 해당하는 구독함이 없습니다.',
           type: DocumentedException,
         }),
       );

--- a/src/entities/categoryPerSubscribes.entity.ts
+++ b/src/entities/categoryPerSubscribes.entity.ts
@@ -6,9 +6,9 @@ export class CategoryPerSubscribeBoxEntity {
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'box_id' })
-  subsribeBox: SubscribeBox;
+  subscribeBox: SubscribeBox;
   @PrimaryColumn({ name: 'box_id', type: 'integer' })
-  boxId: number;
+  box_id: number;
 
   @ManyToOne(() => Category, (category) => category.categoryPerUsers, {
     onDelete: 'CASCADE',

--- a/src/entities/subscribeBox.entity.ts
+++ b/src/entities/subscribeBox.entity.ts
@@ -22,7 +22,7 @@ export class SubscribeBox {
 
   @OneToMany(
     () => CategoryPerSubscribeBoxEntity,
-    (category) => category.subsribeBox,
+    (category) => category.subscribeBox,
   )
   categories: CategoryPerSubscribeBoxEntity[];
 

--- a/src/subscribe/dtos/subscribeBoxRequest.dto.ts
+++ b/src/subscribe/dtos/subscribeBoxRequest.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class SubscribeBoxRequestDto {
+  @ApiProperty({
+    description: '구독함 이름',
+    example: '내 구독함',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '메일 받을 이메일 주소',
+    example: 'example@korea.ac.kr',
+  })
+  email: string;
+
+  @ApiProperty({ description: '구독할 학과', example: '정보대학' })
+  provider: string;
+
+  @ApiProperty({
+    description: '구독할 카테고리 목록 (not mapped)',
+    example: '["학부 공지사항", "진로정보 - 인턴"]',
+  })
+  categories: string[];
+}

--- a/src/subscribe/dtos/subscribeBoxResponse.dto.ts
+++ b/src/subscribe/dtos/subscribeBoxResponse.dto.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Category,
+  CategoryPerSubscribeBoxEntity,
+  Provider,
+  ScrapBox,
+  SubscribeBox,
+} from 'src/entities';
+import { SubscribeBoxRequestDto } from './subscribeBoxRequest.dto';
+
+export class SubscribeBoxResponseDto {
+  @ApiProperty({
+    description: '구독함 id',
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '구독함 이름',
+    example: '내 구독함',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '구독한 이메일 주소',
+    example: 'example@korea.ac.kr',
+  })
+  email: string;
+
+  @ApiProperty({ description: '구독된 학과', example: '정보대학' })
+  provider: string;
+
+  @ApiProperty({
+    description: '구독된 카테고리 목록 (not mapped)',
+    example: '["학부 공지사항", "진로정보 - 인턴"]',
+  })
+  categories: string[];
+
+  static entityToDto(entity: SubscribeBox): SubscribeBoxResponseDto {
+    return {
+      id: entity.id,
+      name: entity.name,
+      email: entity.mail,
+      provider: entity.categories[0].category.provider.name,
+      categories: entity.categories.map((category) => {
+        return category.category.name;
+      }),
+    };
+  }
+}

--- a/src/subscribe/dtos/subscribeBoxResponse.dto.ts
+++ b/src/subscribe/dtos/subscribeBoxResponse.dto.ts
@@ -27,11 +27,11 @@ export class SubscribeBoxResponseDto {
   })
   email: string;
 
-  @ApiProperty({ description: '구독된 학과', example: '정보대학' })
+  @ApiProperty({ description: '구독한 학과', example: '정보대학' })
   provider: string;
 
   @ApiProperty({
-    description: '구독된 카테고리 목록 (not mapped)',
+    description: '구독한 카테고리 목록 (not mapped)',
     example: '["학부 공지사항", "진로정보 - 인턴"]',
   })
   categories: string[];

--- a/src/subscribe/dtos/subscribeBoxResponseWithNotices.dto.ts
+++ b/src/subscribe/dtos/subscribeBoxResponseWithNotices.dto.ts
@@ -1,0 +1,24 @@
+import { NoticeListResponseDto } from 'src/notice/dtos/NoticeListResponse.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Notice, ScrapBox, SubscribeBox } from 'src/entities';
+import { SubscribeBoxResponseDto } from './subscribeBoxResponse.dto';
+
+export class SubscribeBoxResponseDtoWithNotices extends SubscribeBoxResponseDto {
+  @ApiProperty({
+    description: '구독함에 포함된 공지사항들',
+  })
+  notices: NoticeListResponseDto[];
+
+  static toDto(
+    entity: SubscribeBox,
+    notices: Notice[],
+    scrapBoxes: ScrapBox[],
+  ): SubscribeBoxResponseDtoWithNotices {
+    return {
+      ...super.entityToDto(entity),
+      notices: notices.map((notice) => {
+        return NoticeListResponseDto.entityToDto(notice, scrapBoxes);
+      }),
+    };
+  }
+}

--- a/src/subscribe/subscribe.controller.ts
+++ b/src/subscribe/subscribe.controller.ts
@@ -68,7 +68,7 @@ export class SubscribeController {
   ): Promise<SubscribeBoxResponseDto> {
     return await this.subscribeService.updateSubscribeBox(
       subscribeBoxId,
-      1, //user.id,
+      user.id,
       body,
     );
   }

--- a/src/subscribe/subscribe.controller.ts
+++ b/src/subscribe/subscribe.controller.ts
@@ -1,0 +1,88 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { SubscribeService } from './subscribe.service';
+import { AuthGuard } from '@nestjs/passport';
+import { Docs } from 'src/decorators/docs/subscribe.decorator';
+import { SubscribeBoxRequestDto } from './dtos/subscribeBoxRequest.dto';
+import { JwtPayload } from 'src/interfaces/auth';
+import { User } from 'src/decorators';
+import { SubscribeBoxResponseDtoWithNotices } from './dtos/subscribeBoxResponseWithNotices.dto';
+import { SubscribeBoxResponseDto } from './dtos/subscribeBoxResponse.dto';
+import { ApiTags } from '@nestjs/swagger';
+
+@ApiTags('Subscribe')
+@Controller('subscribe')
+export class SubscribeController {
+  constructor(private readonly subscribeService: SubscribeService) {}
+
+  @UseGuards(AuthGuard('jwt-access'))
+  @Post('/box')
+  @Docs('createSubscribeBox')
+  async createSubscribeBox(
+    @Body() body: SubscribeBoxRequestDto,
+    @User() user: JwtPayload,
+  ): Promise<SubscribeBoxResponseDto> {
+    return await this.subscribeService.createSubscribeBox(user.id, body);
+  }
+
+  @UseGuards(AuthGuard('jwt-access'))
+  @Get('/box/:subscribeBoxId')
+  @Docs('getSubscribeBoxInfo')
+  async getSubscribeInfo(
+    @Param('subscribeBoxId') subscribeBoxId: number,
+    @User() user: JwtPayload,
+    @Query('date') date: string,
+  ): Promise<SubscribeBoxResponseDtoWithNotices> {
+    return await this.subscribeService.getSubscribeBoxInfo(
+      user.id,
+      subscribeBoxId,
+      date,
+    );
+  }
+
+  @UseGuards(AuthGuard('jwt-access'))
+  @Get('/box')
+  @Docs('getSubscribeBoxes')
+  async getSubscribees(
+    @User() user: JwtPayload,
+  ): Promise<SubscribeBoxResponseDto[]> {
+    return await this.subscribeService.getSubscribeBoxes(user.id);
+  }
+
+  @UseGuards(AuthGuard('jwt-access'))
+  @Put('/box/:subscribeBoxId')
+  @Docs('updateSubscribeBox')
+  async updateSubscribe(
+    @Param('subscribeBoxId') subscribeBoxId: number,
+    @User() user: JwtPayload,
+    @Body() body: SubscribeBoxRequestDto,
+  ): Promise<SubscribeBoxResponseDto> {
+    return await this.subscribeService.updateSubscribeBox(
+      subscribeBoxId,
+      1, //user.id,
+      body,
+    );
+  }
+
+  @UseGuards(AuthGuard('jwt-access'))
+  @Delete('/box/:subscribeBoxId')
+  @Docs('deleteSubscribeBox')
+  async deleteSubscribe(
+    @Param('subscribeBoxId') subscribeBoxId: number,
+    @User() user: JwtPayload,
+  ): Promise<void> {
+    return await this.subscribeService.deleteSubscribeBox(
+      subscribeBoxId,
+      user.id,
+    );
+  }
+}

--- a/src/subscribe/subscribe.module.ts
+++ b/src/subscribe/subscribe.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { SubscribeService } from './subscribe.service';
+import {
+  Category,
+  CategoryPerSubscribeBoxEntity,
+  Notice,
+  ScrapBox,
+  SubscribeBox,
+} from 'src/entities';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SubscribeController } from './subscribe.controller';
+
+@Module({
+  controllers: [SubscribeController],
+  providers: [SubscribeService],
+
+  imports: [
+    TypeOrmModule.forFeature([
+      SubscribeBox,
+      Category,
+      Notice,
+      ScrapBox,
+      CategoryPerSubscribeBoxEntity,
+    ]),
+  ],
+})
+export class SubscribeModule {}

--- a/src/subscribe/subscribe.service.ts
+++ b/src/subscribe/subscribe.service.ts
@@ -1,0 +1,212 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { SubscribeBoxRequestDto } from './dtos/subscribeBoxRequest.dto';
+import { SubscribeBoxResponseDto } from './dtos/subscribeBoxResponse.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import {
+  Category,
+  CategoryPerSubscribeBoxEntity,
+  Notice,
+  ScrapBox,
+  SubscribeBox,
+} from 'src/entities';
+import { SubscribeBoxResponseDtoWithNotices } from './dtos/subscribeBoxResponseWithNotices.dto';
+import { NoticeListResponseDto } from 'src/notice/dtos/NoticeListResponse.dto';
+
+@Injectable()
+export class SubscribeService {
+  constructor(
+    @InjectRepository(SubscribeBox)
+    private readonly subscribeBoxRepository: Repository<SubscribeBox>,
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+    @InjectRepository(Notice)
+    private readonly noticeRepository: Repository<Notice>,
+    @InjectRepository(ScrapBox)
+    private readonly scrapBoxRepository: Repository<ScrapBox>,
+    @InjectRepository(CategoryPerSubscribeBoxEntity)
+    private readonly categoryPerSubscribeBoxRepository: Repository<CategoryPerSubscribeBoxEntity>,
+  ) {}
+
+  async createSubscribeBox(
+    userId: number,
+    dto: SubscribeBoxRequestDto,
+  ): Promise<SubscribeBoxResponseDto> {
+    const subscribeBox = await this.subscribeBoxRepository.insert({
+      name: dto.name,
+      mail: dto.email,
+      user: { id: userId },
+    });
+
+    const categories = await this.categoryRepository.find({
+      where: { name: In(dto.categories), provider: { name: dto.provider } },
+    });
+    const subscriptions: CategoryPerSubscribeBoxEntity[] = [];
+    categories.forEach((category) => {
+      const subscription: CategoryPerSubscribeBoxEntity = {
+        subscribeBox: subscribeBox.raw[0],
+        box_id: subscribeBox.raw[0].id,
+        category_id: category.id,
+        category: category,
+      };
+      subscriptions.push(subscription);
+    });
+    await this.categoryPerSubscribeBoxRepository.save(subscriptions);
+
+    const box = await this.subscribeBoxRepository.findOne({
+      where: { id: subscribeBox.raw[0].id },
+      relations: [
+        'categories',
+        'categories.category',
+        'categories.category.provider',
+      ],
+    });
+    return SubscribeBoxResponseDto.entityToDto(box);
+  }
+
+  async getSubscribeBoxes(userId: number): Promise<SubscribeBoxResponseDto[]> {
+    const subscribeBoxes = await this.subscribeBoxRepository.find({
+      where: { user: { id: userId } },
+      relations: [
+        'categories',
+        'categories.category',
+        'categories.category.provider',
+      ],
+    });
+    return subscribeBoxes.map((subscribeBox) => {
+      return SubscribeBoxResponseDto.entityToDto(subscribeBox);
+    });
+  }
+
+  async getSubscribeBoxInfo(
+    userId: number,
+    subscribeBoxId: number,
+    date: string,
+  ): Promise<SubscribeBoxResponseDtoWithNotices> {
+    const subscribeBox = await this.subscribeBoxRepository.findOne({
+      where: { id: subscribeBoxId },
+      relations: [
+        'categories',
+        'categories.category',
+        'categories.category.provider',
+        'user',
+      ],
+    });
+    const notices = await this.noticeRepository.find({
+      where: {
+        date: date,
+        category: In(
+          subscribeBox.categories.map((category) => {
+            return category.category_id;
+          }),
+        ),
+      },
+      relations: ['category.provider'],
+    });
+
+    const scrapBoxes = await this.scrapBoxRepository.find({
+      where: {
+        user: { id: userId },
+      },
+      relations: ['scraps'],
+    });
+    if (!subscribeBox)
+      throw new NotFoundException('해당 구독함이 존재하지 않습니다');
+    if (subscribeBox.user.id !== userId)
+      throw new ForbiddenException('권한이 없습니다');
+    return SubscribeBoxResponseDtoWithNotices.toDto(
+      subscribeBox,
+      notices,
+      scrapBoxes,
+    );
+  }
+
+  async updateSubscribeBox(
+    subscribeBoxId: number,
+    userId: number,
+    dto: SubscribeBoxRequestDto,
+  ): Promise<SubscribeBoxResponseDto> {
+    const subscribeBox = await this.subscribeBoxRepository.findOne({
+      where: { id: subscribeBoxId },
+      relations: ['user', 'categories'],
+    });
+    if (!subscribeBox)
+      throw new NotFoundException('해당 구독함이 존재하지 않습니다');
+    if (subscribeBox.user.id !== userId)
+      throw new ForbiddenException('권한이 없습니다');
+
+    subscribeBox.mail = dto.email;
+    subscribeBox.name = dto.name;
+
+    await this.subscribeBoxRepository.save(subscribeBox);
+
+    const categories = await this.categoryRepository.find({
+      where: { name: In(dto.categories), provider: { name: dto.provider } },
+    });
+
+    const categoriesToDelete: CategoryPerSubscribeBoxEntity[] =
+      subscribeBox.categories.filter((category) => {
+        return !categories.some((c) => c.id === category.category_id);
+      });
+    if (categoriesToDelete.length > 0) {
+      await Promise.all(
+        categoriesToDelete.map(
+          async (category) =>
+            await this.categoryPerSubscribeBoxRepository.delete({
+              category_id: category.category_id,
+              box_id: subscribeBoxId,
+            }),
+        ),
+      );
+    }
+
+    const categoriesToAdd: Category[] = categories.filter((category) => {
+      return !subscribeBox.categories.some(
+        (c) => c.category_id === category.id,
+      );
+    });
+
+    const subscriptions: CategoryPerSubscribeBoxEntity[] = [];
+    categoriesToAdd.forEach((category) => {
+      const subscription: CategoryPerSubscribeBoxEntity = {
+        subscribeBox: subscribeBox,
+        box_id: subscribeBox.id,
+        category_id: category.id,
+        category: category,
+      };
+      subscriptions.push(subscription);
+    });
+
+    await this.categoryPerSubscribeBoxRepository.save(subscriptions);
+    const box = await this.subscribeBoxRepository.findOne({
+      where: { id: subscribeBox.id },
+      relations: [
+        'categories',
+        'categories.category',
+        'categories.category.provider',
+      ],
+    });
+
+    return SubscribeBoxResponseDto.entityToDto(box);
+  }
+
+  async deleteSubscribeBox(
+    subscribeBoxId: number,
+    userId: number,
+  ): Promise<void> {
+    const subscribeBox = await this.subscribeBoxRepository.findOne({
+      where: { id: subscribeBoxId },
+      relations: ['user'],
+    });
+    if (!subscribeBox)
+      throw new NotFoundException('해당 구독함이 존재하지 않습니다');
+    if (subscribeBox.user.id !== userId)
+      throw new ForbiddenException('권한이 없습니다');
+    await this.subscribeBoxRepository.delete(subscribeBoxId);
+  }
+}


### PR DESCRIPTION
## PR 포함 사항
- 구독함 생성, 삭제, 수정, 조회 및 구독함 세부 정보 조회
- 구독함 세부 정보 조회는 날짜별 notice를 가져오기 위해 날짜 정보를 필수로 입력해야 함.

## TODO
- 조인이 너무 많이 일어나서 코드/entity 리팩토링 필요
- 여러 논의사항 함께 논의 후 코드 수정 필요

## 논의사항
- 구독함 정보를 가져올 때 조인이 너무 많이 일어남
- 구독함 생성/수정 시 모든 작업이 끝나고 마지막에 다시 한번 조회하여 값을 반환하고 있는데 괜찮을지? (여러 테이블을 조인하여 조회하기 위해 다시 한번 조회했음)
- 구독함 수정 시 현재 구독 중인 카테고리와 비교하여 삭제 및 삽입을 해주고 있는데 모두 다 지우고 다 넣는 게 cost가 덜 들지 고민

## Test
